### PR TITLE
chore(scale): 修改汉密尔顿抑郁量表警告语

### DIFF
--- a/src/scale/hamd.rs
+++ b/src/scale/hamd.rs
@@ -19,7 +19,7 @@ pub const HAMILTON_DEPRESSION_SCALE: Scale<&[InterpretationItem<i8>], Question> 
     idea: None,
     instruction: INSTRUCTION,
     references: Some(&["张作记主编.《行为医学量表手册》（光盘版）[M].中华医学电子音像出版社.2005年"]),
-    warning: Some("此为医用临床评定抑郁状态的量表，非自评量表，仅供参考，如需自评抑郁状态，请使用抑郁自评量表(SDS)"),
+    warning: Some("此为医用量表，包含心理学和精神病学专用词语，仅供心理科和精神科医生、实习生使用，如需自评抑郁状态，请使用抑郁自评量表(SDS)"),
     formula_mode: None,
     tags: Tag{ info: None, normal: None, warning: Some(&["医用"]), error: None },
     interpretation: &[


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated warning message for the Hamilton Depression Scale to clarify the intended audience as mental health professionals and interns.
	- Enhanced specificity regarding the nature of the content, aiding users in interpreting and applying the scale correctly in clinical settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->